### PR TITLE
fix requestProxy url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "weweb-cli",
+  "name": "strikingly-weweb-cli",
   "version": "1.0.2",
-  "description": "微信小程序转成h5的小工具",
+  "description": "修正 requestProxy",
   "main": "bin/weweb",
   "bin": {
     "weweb": "bin/weweb"
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/wdfe/weweb.git"
+    "url": "https://github.com/iShawnWang/weweb.git"
   },
   "author": "wdfe",
   "license": "MIT",

--- a/src/service/bridge/proxyRequirst.js
+++ b/src/service/bridge/proxyRequirst.js
@@ -50,7 +50,7 @@ var request = function (event, params, callback) {
     method = params.method || 'POST',
     networkTimeout = 3e4
   if (__wxConfig__ && __wxConfig__.weweb && __wxConfig__.weweb.requestProxy) {
-    requestObj.open(method, __wxConfig__.weweb.requestProxy, true)
+    requestObj.open(method, url, true)
     requestObj.onreadystatechange = function () {
       if ((requestObj.readyState == 3, requestObj.readyState == 4)) {
         requestObj.onreadystatechange = null


### PR DESCRIPTION
For this section : 

---
- 跨域请求：当后端接口不支持JSONP时，可以增加requestProxy配置项来设置服务器端代理地址，以实现跨域请求

```
/**
 * 此处/remoteProxy是weweb自带server实现的一个代理接口
 * 实际项目中请改成自己的真实代理地址。如果接口支持返回jsonp格式，则无需做此配置
 */

"weweb":{
  "requestProxy":"/remoteProxy"
}
```

---

if I set `"requestProxy":"http://localhost:3000"` ,
all the request url will be `http://localhost:3000`.
So, I just modify the line below ~