### PR TITLE
css文件转换时。 类似于 .story-item:nth-child(1) 这种样式，会被转换成 .story-item:nth-child(wx-1)，导致，选择器样式失效。

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -114,6 +114,7 @@ module.exports = function (fullPath) {
               return reject(new Error(`${fullPath} 编译失败，请检查`))
             }
             wxssSourcemap(fullPath, stdout).then(content => {
+              content = content.replace(/\(wx-/g,'(') //替换css文件中的wx-1 2 3 4,子元素选择器bug, story-item:nth-child(1)
               cache.set(fullPath, content)
               resolve(content)
             }, reject)
@@ -127,6 +128,7 @@ module.exports = function (fullPath) {
           }
           wxssTranspile(srcs, { keepSlash: true }).then(stdout => {
             wxssSourcemap(fullPath, stdout).then(content => {
+              content = content.replace(/\(wx-/g,'(') //替换css文件中的wx-1 2 3 4,子元素选择器bug,story-item:nth-child(1)
               cache.set(fullPath, content)
               resolve(content)
             }, reject)


### PR DESCRIPTION
问题：
css文件转换时。
类似于 .story-item:nth-child(1) 这种样式，会被转换成 .story-item:nth-child(wx-1)
导致，选择器样式失效。

方法：
替换css文件中的wx-1 2 3 4,子元素选择器bug,