### PR TITLE
修改一批内容

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -146,9 +146,12 @@ success : function(rt){
 ```
 
 ## 跨域请求
+
+-  概述：wgweweb默认请求是XHR类型，请求地址和小程序接口地址一致。当后端接口不支持JSONP时，可以增加requestProxy配置项来设置服务器端代理地址，以实现跨域请求
+
 - 方案一：默认使用 JSONP 所以请求最终都变为 Get
 
-- 方案二：使用代理服务器, 在 app.json 中增加如下字段
+- 方案二：使用代理服务器, 项目根目录新建 ext.json 中增加如下字段
 
 ``` js
 /**
@@ -161,7 +164,7 @@ success : function(rt){
 }
 ```
 
-- 方案三：服务器配置好 cors 请求头, 并在 app.json 中增加如下字段
+- 方案三：服务器配置好 cors 请求头, 项目根目录新建 ext.json 并增加如下字段
 ```
 "weweb":{
   "requestType": "ajax"

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -134,7 +134,7 @@ exports.buildPage = function (file) {
 }
 
 function customizeCode (str) {
-  return str.replace(/wx\./g, "wgweb_wx.")
+  return str.replace(/wx\./g, "weweb_wx.")
   // .replace(/Object\.defineProperty\(\s*wx\s*,/g, 'Object.defineProperty(wd,')
   // .replace(/([^a-zA-Z/])Reporter/g, '$1SReporter')
 }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -134,8 +134,7 @@ exports.buildPage = function (file) {
 }
 
 function customizeCode (str) {
-  return str.replace(/WeixinJSBridge/g, 'ServiceJSBridge')
-  // .replace(/([^a-zA-Z/])wx\./g, '$1wd.')
+  return str.replace(/wx\./g, "wgweb_wx.")
   // .replace(/Object\.defineProperty\(\s*wx\s*,/g, 'Object.defineProperty(wd,')
   // .replace(/([^a-zA-Z/])Reporter/g, '$1SReporter')
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,17 @@
 const fs = require('fs')
 const merge = require('merge')
 const Parallel = require('node-parallel')
+
+
 let scopeConfig = null
+
+
+/**
+ * 设置默认的配置，可在ext.json文件中将以下内容覆盖
+  requestType: "ajax",
+  websiteIcon:"https://gouhuo.qq.com/favicon.ico",
+  websiteTitle:'WeChat'
+*/
 let default_config = {
   debug: false,
   babel: false,
@@ -19,7 +29,12 @@ let default_config = {
     gender: 1,
     nickName: '测试帐号',
     province: 'Beijing'
-  }
+  },
+  weweb:{
+    requestType: "ajax",
+  },
+  websiteIcon:"https://gouhuo.qq.com/favicon.ico",
+  websiteTitle:'WeChat'
 }
 
 module.exports = function (opt) {
@@ -35,12 +50,14 @@ module.exports = function (opt) {
               return done(new Error('No pages found'))
             }
             config.root = config.root || config.pages[0]
+
             done(null, config)
           } catch (e) {
             return done(e)
           }
         })
       })
+      
       if (fs.existsSync('./ext.json')) {
         p.add(done => {
           fs.readFile('./ext.json', 'utf8', (err, data) => {

--- a/lib/core.js
+++ b/lib/core.js
@@ -5,7 +5,7 @@ const loadConfig = require('./config')
 const util = require('./util')
 const cache = require('./cache')
 const parser = require('./parser')
-const version = require('../package.json').version
+const version = require('../package.json').version + '.' + new Date().getTime()
 const builder = require('./builder')
 
 function escape (x) {
@@ -50,6 +50,7 @@ exports.getIndex = async function () {
   return rootFn(
     {
       config: JSON.stringify(config),
+      configObject: config,
       root: config.root,
       // ip: util.getIp(),
       topBar: topBar,

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -114,6 +114,7 @@ module.exports = function (fullPath) {
               return reject(new Error(`${fullPath} 编译失败，请检查`))
             }
             wxssSourcemap(fullPath, stdout).then(content => {
+              content = content.replace(/\(wx-/g,'(') //替换css文件中的wx-1 2 3 4,子元素选择器bug, story-item:nth-child(1)
               cache.set(fullPath, content)
               resolve(content)
             }, reject)
@@ -127,6 +128,7 @@ module.exports = function (fullPath) {
           }
           wxssTranspile(srcs, { keepSlash: true }).then(stdout => {
             wxssSourcemap(fullPath, stdout).then(content => {
+              content = content.replace(/\(wx-/g,'(') //替换css文件中的wx-1 2 3 4,子元素选择器bug,story-item:nth-child(1)
               cache.set(fullPath, content)
               resolve(content)
             }, reject)

--- a/lib/router.js
+++ b/lib/router.js
@@ -20,7 +20,7 @@ const tmpDir = path.join(osTmp, hash_dir)
 mkdir.sync(tmpDir)
 const root =
   require('os').platform == 'win32' ? process.cwd().split(path.sep)[0] : '/'
-const version = require('../package.json').version
+const version = require('../package.json').version + '.' + new Date().getTime()
 const builder = require('./builder')
 const api = require('./api')
 
@@ -63,6 +63,7 @@ router.get('/', function * () {
   this.body = rootFn(
     {
       config: JSON.stringify(config),
+      configObject: config,
       root: config.root,
       ip: util.getIp(),
       topBar: topBar,

--- a/lib/template/index.html
+++ b/lib/template/index.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-  <link href="https://res.wx.qq.com/mpres/htmledition/images/favicon218877.ico" rel="Shortcut Icon">
+  <link href="{{= _.configObject.websiteIcon}}" rel="Shortcut Icon">
   <meta charset="UTF-8" />
-  <link rel="stylesheet" type="text/css" href="css/weweb.min.css">
+  <link rel="stylesheet" type="text/css" href="css/weweb.min.css?v={{= _.version}}">
   <meta name="viewport" content="width=device-width, height=device-height,user-scalable=no, initial-scale=1.0" />
+  <title>{{= _.configObject.websiteTitle}}</title>
   <!-- <script src="/script/recorder.js"></script> -->
 </head>
 <body>

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -494,7 +494,7 @@ const utils = {
         distObj.__defineGetter__(attrName, function () {
           return Reporter.surroundThirdByTryCatch(
             orgObj[attrName],
-            'wx.' + attrName
+            'wgweb_wx.' + attrName
           )
         })
       })(attrName)

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -494,7 +494,7 @@ const utils = {
         distObj.__defineGetter__(attrName, function () {
           return Reporter.surroundThirdByTryCatch(
             orgObj[attrName],
-            'wgweb_wx.' + attrName
+            'weweb_wx.' + attrName
           )
         })
       })(attrName)

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -842,8 +842,9 @@ const utils = {
         }, {}),
         urlQueryArr = []
       for (var i in queryParams) {
+        //解决页面跳转带特殊参数传参出现解码失败的问题--会重复encode
         queryParams.hasOwnProperty(i) &&
-          urlQueryArr.push(i + '=' + encodeURIComponent(queryParams[i]))
+          urlQueryArr.push(i + '=' + encodeURIComponent(decodeURIComponent(queryParams[i])))
       }
       return urlQueryArr.length > 0
         ? urlPath + '?' + urlQueryArr.join('&')

--- a/src/service/amdEngine.js
+++ b/src/service/amdEngine.js
@@ -78,8 +78,8 @@ export { define, require }
 window.define = define
 window.require = require
 
-wx.version = {
-  updateTime: '2017.12.14 16:51:56',
+wgweb_wx.version = {
+  updateTime: '2019.05.27 11:51:56',
   info: '',
-  version: 32
+  version: 2
 }

--- a/src/service/amdEngine.js
+++ b/src/service/amdEngine.js
@@ -78,7 +78,7 @@ export { define, require }
 window.define = define
 window.require = require
 
-wgweb_wx.version = {
+weweb_wx.version = {
   updateTime: '2019.05.27 11:51:56',
   info: '',
   version: 2

--- a/src/service/api/index.js
+++ b/src/service/api/index.js
@@ -281,7 +281,7 @@ var apiObj = {
       arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : {}
     if (paramCheck('switchTab', params, { url: '' })) {
       ;/\?.*$/.test(params.url) &&
-        (console.warn('wgweb_wx.switchTab: url 不支持 queryString'),
+        (console.warn('weweb_wx.switchTab: url 不支持 queryString'),
           (params.url = params.url.replace(/\?.*$/, '')))
       params.url = utils.getRealRoute(currUrl, params.url)
       params.url = utils.encodeUrlQuery(params.url)
@@ -1829,5 +1829,5 @@ bridge.onMethod('onMapClick', function () {
 })
 
 utils.copyObj(wx, apiObj)
-window.wgweb_wx = wx
+window.weweb_wx = wx
 export default wx

--- a/src/service/api/index.js
+++ b/src/service/api/index.js
@@ -281,7 +281,7 @@ var apiObj = {
       arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : {}
     if (paramCheck('switchTab', params, { url: '' })) {
       ;/\?.*$/.test(params.url) &&
-        (console.warn('wx.switchTab: url 不支持 queryString'),
+        (console.warn('wgweb_wx.switchTab: url 不支持 queryString'),
           (params.url = params.url.replace(/\?.*$/, '')))
       params.url = utils.getRealRoute(currUrl, params.url)
       params.url = utils.encodeUrlQuery(params.url)
@@ -1829,5 +1829,5 @@ bridge.onMethod('onMapClick', function () {
 })
 
 utils.copyObj(wx, apiObj)
-window.wx = wx
+window.wgweb_wx = wx
 export default wx

--- a/src/service/api/index.js
+++ b/src/service/api/index.js
@@ -262,6 +262,20 @@ var apiObj = {
         })
     }
   },
+  //跳转到其它小程序，这里需要额外加一个小程序名字，或者目标的域名给h5使用
+  navigateToMiniProgram: function (params) {
+    arguments.length > 1 && void 0 !== arguments[1] && arguments[1]
+    bridge.invokeMethod('showToast', {title:`请打开【${params.appName}】小程序查看更多功能`})
+    bridge.invokeMethod('navigateToMiniProgram', params)
+  },
+  showShareMenu : function (params) {
+    console.log('showShareMenu, todo')
+    bridge.invokeMethod('showShareMenu', {})
+  },
+  hideShareMenu: function (params) {
+    console.log('hideShareMenu, todo')
+    bridge.invokeMethod('hideShareMenu', {})
+  },
   switchTab: function () {
     var params =
       arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : {}
@@ -940,6 +954,20 @@ var apiObj = {
       }
     )
   },
+
+  //这个方法，暂时没啥用
+  getSetting: function (params) {
+    console.log('getSetting', params)
+    utils.assign(
+      {
+        success:()=>{},
+        fail:()=>{},
+        complete:()=>{}
+      },
+      params
+    );
+  },
+
   getFriends: function (params) {
     bridge.invokeMethod(
       'operateWXData',

--- a/src/service/bridge/command.js
+++ b/src/service/bridge/command.js
@@ -163,6 +163,19 @@ export function navigateTo (data) {
   router.navigateTo(data.args.url)
 }
 
+//跳转到其它小程序，这里需要额外加一个小程序名字，或者目标的域名给h5使用
+export function navigateToMiniProgram(params) {
+  console.log('navigateToMiniProgram, todo')
+}
+//分享信息
+export function showShareMenu (params) {
+  console.log('showShareMenu, todo')
+}
+
+export function hideShareMenu(params) {
+  console.log('hideShareMenu, todo')
+}
+
 export function reLaunch (data) {
   router.reLaunch(data.args.url)
 }

--- a/src/service/bridge/command.js
+++ b/src/service/bridge/command.js
@@ -816,7 +816,7 @@ export function showPickerView (args) {
   picker.show()
   // picker.on('cancel', () => {})
   picker.on('select', n => {
-    WgWebServiceJSBridge.subscribeHandler('showPickerView', {
+    WeWebServiceJSBridge.subscribeHandler('showPickerView', {
       errMsg: 'showPickerView:ok',
       index: n
     })
@@ -828,7 +828,7 @@ export function insertHTMLWebView (args) {
     'webview_site_' + args.htmlId,
     document.querySelector(`#weweb-view-${window.__webviewId__}`)
   )
-  WgWebServiceJSBridge.subscribeHandler('insertHTMLWebView', {
+  WeWebServiceJSBridge.subscribeHandler('insertHTMLWebView', {
     errMsg: 'insertHTMLWebView:ok'
   })
 }
@@ -847,7 +847,7 @@ export function showDatePickerView (args) {
 
   picker.show()
   picker.on('select', val => {
-    WgWebServiceJSBridge.subscribeHandler('showDatePickerView', {
+    WeWebServiceJSBridge.subscribeHandler('showDatePickerView', {
       errMsg: 'showDatePickerView:ok',
       value: val
     })

--- a/src/service/bridge/command.js
+++ b/src/service/bridge/command.js
@@ -816,7 +816,7 @@ export function showPickerView (args) {
   picker.show()
   // picker.on('cancel', () => {})
   picker.on('select', n => {
-    WeixinJSBridge.subscribeHandler('showPickerView', {
+    WgWebServiceJSBridge.subscribeHandler('showPickerView', {
       errMsg: 'showPickerView:ok',
       index: n
     })
@@ -828,7 +828,7 @@ export function insertHTMLWebView (args) {
     'webview_site_' + args.htmlId,
     document.querySelector(`#weweb-view-${window.__webviewId__}`)
   )
-  WeixinJSBridge.subscribeHandler('insertHTMLWebView', {
+  WgWebServiceJSBridge.subscribeHandler('insertHTMLWebView', {
     errMsg: 'insertHTMLWebView:ok'
   })
 }
@@ -847,7 +847,7 @@ export function showDatePickerView (args) {
 
   picker.show()
   picker.on('select', val => {
-    WeixinJSBridge.subscribeHandler('showDatePickerView', {
+    WgWebServiceJSBridge.subscribeHandler('showDatePickerView', {
       errMsg: 'showDatePickerView:ok',
       value: val
     })

--- a/src/service/bridge/index.js
+++ b/src/service/bridge/index.js
@@ -42,7 +42,7 @@ var userApi = {
   },
   authorize: function (event, temp, sendMsg) {
     sendMsg({
-      errMsg: 'authorize:fail'
+      errMsg: 'authorize:ok'
     })
   },
   operateWXData: function (event, temp, sendMsg) {

--- a/src/service/engine/initApp.js
+++ b/src/service/engine/initApp.js
@@ -88,8 +88,8 @@ class App {
             reportRealtimeAction.triggerAnalytics('foreground', null, '小程序转到前台'))
       }
     }
-    wgweb_wx.onAppEnterBackground(hide.bind(this))
-    wgweb_wx.onAppEnterForeground(show.bind(this))
+    weweb_wx.onAppEnterBackground(hide.bind(this))
+    weweb_wx.onAppEnterForeground(show.bind(this))
   }
   getCurrentPage () {
     utils.warn(

--- a/src/service/engine/initApp.js
+++ b/src/service/engine/initApp.js
@@ -88,8 +88,8 @@ class App {
             reportRealtimeAction.triggerAnalytics('foreground', null, '小程序转到前台'))
       }
     }
-    wx.onAppEnterBackground(hide.bind(this))
-    wx.onAppEnterForeground(show.bind(this))
+    wgweb_wx.onAppEnterBackground(hide.bind(this))
+    wgweb_wx.onAppEnterForeground(show.bind(this))
   }
   getCurrentPage () {
     utils.warn(

--- a/src/service/engine/pageInit.js
+++ b/src/service/engine/pageInit.js
@@ -352,7 +352,7 @@ const getRouteToPage = function () {
   return pageRegObjs
 }
 
-wx.onAppRoute(
+wgweb_wx.onAppRoute(
   Reporter.surroundThirdByTryCatch(function (params) {
     var path = params.path,
       webviewId = params.webviewId,
@@ -363,7 +363,7 @@ wx.onAppRoute(
   'onAppRoute'
 )
 
-wx.onWebviewEvent(
+wgweb_wx.onWebviewEvent(
   Reporter.surroundThirdByTryCatch(function (params) {
     var webviewId = params.webviewId,
       eventName = params.eventName,

--- a/src/service/engine/pageInit.js
+++ b/src/service/engine/pageInit.js
@@ -352,7 +352,7 @@ const getRouteToPage = function () {
   return pageRegObjs
 }
 
-wgweb_wx.onAppRoute(
+weweb_wx.onAppRoute(
   Reporter.surroundThirdByTryCatch(function (params) {
     var path = params.path,
       webviewId = params.webviewId,
@@ -363,7 +363,7 @@ wgweb_wx.onAppRoute(
   'onAppRoute'
 )
 
-wgweb_wx.onWebviewEvent(
+weweb_wx.onWebviewEvent(
   Reporter.surroundThirdByTryCatch(function (params) {
     var webviewId = params.webviewId,
       eventName = params.eventName,

--- a/src/service/engine/parsePage.js
+++ b/src/service/engine/parsePage.js
@@ -9,7 +9,7 @@ const pageEvents = [
   'onRouteEnd',
   'onHide',
   'onUnload'
-]
+];
 const isSysAttr = function (key) {
   // 校验e是否为系统事件或属性
   for (var i = 0; i < pageEvents.length; ++i) {
@@ -172,7 +172,7 @@ class PageParser {
         document.addEventListener('pageReRender', execCallback)
       }
       if (window.reRender) {
-        WeixinJSBridge.subscribeHandler('custom_event_appDataChange', {
+        WgWebServiceJSBridge.subscribeHandler('custom_event_appDataChange', {
           data: {
             data: dataObj
           }

--- a/src/service/engine/parsePage.js
+++ b/src/service/engine/parsePage.js
@@ -172,7 +172,7 @@ class PageParser {
         document.addEventListener('pageReRender', execCallback)
       }
       if (window.reRender) {
-        WgWebServiceJSBridge.subscribeHandler('custom_event_appDataChange', {
+        WeWebServiceJSBridge.subscribeHandler('custom_event_appDataChange', {
           data: {
             data: dataObj
           }

--- a/src/service/lib/header.js
+++ b/src/service/lib/header.js
@@ -17,6 +17,7 @@ let header = {
       backgroundColor: win.navigationBarBackgroundColor,
       color: win.navigationBarTextStyle,
       title: win.navigationBarTitleText,
+      navigationStyle: win.navigationStyle,
       loading: false,
       backText: '返回',
       back: false,
@@ -24,6 +25,7 @@ let header = {
     }
     if (!this.dom) {
       this.dom = {
+        headContainer: this.$('.jshook-ws-head').parentElement, //顶部导航的容器
         head: this.$('.jshook-ws-head'),
         headBack: this.$('.jshook-ws-head-back'),
         headBackText: this.$('.jshook-ws-head-back-text'),
@@ -40,7 +42,15 @@ let header = {
       this.dom.headHome.onclick = this.onHome.bind(null)
       this.dom.headOption.onclick = this.onOptions.bind(null)
     }
-    this.dom.head.style.display = 'block'
+
+    //navigationStyle == 'custom'时，隐藏顶栏容器，同时把底下的容器位移变高
+    if(win.navigationStyle == 'custom'){
+      this.dom.headContainer.style.display = 'none';
+      this.$('.scrollable').style.top = '0px';
+    }else{
+      this.dom.headContainer.style.display = 'block';
+    }
+
     Bus.on('route', this.reset.bind(this))
     this.setState()
   },
@@ -48,10 +58,11 @@ let header = {
     return document.querySelector(name)
   },
   reset: function () {
-    let d = {
+    let temp = {
       backgroundColor: win.navigationBarBackgroundColor,
       color: win.navigationBarTextStyle,
       title: win.navigationBarTitleText,
+      isCustomNavigationStyle: (win.navigationStyle == 'custom'),
       loading: false,
       back: false
     }
@@ -62,6 +73,9 @@ let header = {
 
     let top = tabBar && tabBar.position == 'top'
     let hide = top && util.isTabbar(curr.url)
+    if(temp.isCustomNavigationStyle){
+      hide = true
+    }
     if (curr.isMap) {
       this.setState({
         hide: false,
@@ -76,9 +90,9 @@ let header = {
       this.setState({
         hide,
         backgroundColor:
-          winConfig.navigationBarBackgroundColor || d.backgroundColor,
-        color: winConfig.navigationBarTextStyle || d.color,
-        title: winConfig.navigationBarTitleText || d.title,
+          winConfig.navigationBarBackgroundColor || temp.backgroundColor,
+        color: winConfig.navigationBarTextStyle || temp.color,
+        title: winConfig.navigationBarTitleText || temp.title,
         loading: false,
         backText: '返回',
         sendText: false,

--- a/src/service/router/index.js
+++ b/src/service/router/index.js
@@ -112,7 +112,7 @@ function onBack () {
 function onNavigate (url, type = 'navigateTo') {
   if (!url) throw new Error('url not found')
   if (type == 'reLaunch' && util.isTabbar(curr.path) && curr.query) {
-    console.error('wx.reLaunch 跳转到 tabbar 页面时不允许携带参数，请去除参数或使用 wx.switchTab')
+    console.error('wgweb_wx.reLaunch 跳转到 tabbar 页面时不允许携带参数，请去除参数或使用 wx.switchTab')
     return
   }
   curr.onReady(() => {

--- a/src/service/router/index.js
+++ b/src/service/router/index.js
@@ -112,7 +112,7 @@ function onBack () {
 function onNavigate (url, type = 'navigateTo') {
   if (!url) throw new Error('url not found')
   if (type == 'reLaunch' && util.isTabbar(curr.path) && curr.query) {
-    console.error('wgweb_wx.reLaunch 跳转到 tabbar 页面时不允许携带参数，请去除参数或使用 wx.switchTab')
+    console.error('weweb_wx.reLaunch 跳转到 tabbar 页面时不允许携带参数，请去除参数或使用 wx.switchTab')
     return
   }
   curr.onReady(() => {

--- a/src/service/router/view.js
+++ b/src/service/router/view.js
@@ -124,15 +124,15 @@ export default class View extends Emitter {
         ext = data.ext
 
       if (command === 'MSG_FROM_APPSERVICE') {
-        WgWebServiceJSBridge.subscribeHandler(msg.eventName, msg.data)
+        WeWebServiceJSBridge.subscribeHandler(msg.eventName, msg.data)
       } else if (
         command == 'GET_JSSDK_RES' ||
         command == 'INVOKE_SDK' ||
         /^private_/.test(msg.sdkName)
       ) {
-        WgWebServiceJSBridge.subscribeHandler(msg.sdkName, msg.res, ext) // ext其实也没用 了
+        WeWebServiceJSBridge.subscribeHandler(msg.sdkName, msg.res, ext) // ext其实也没用 了
       } else if (command === 'STOP_PULL_DOWN_REFRESH') {
-        WgWebServiceJSBridge.pull.reset()
+        WeWebServiceJSBridge.pull.reset()
       }
     })
   }

--- a/src/service/router/view.js
+++ b/src/service/router/view.js
@@ -124,15 +124,15 @@ export default class View extends Emitter {
         ext = data.ext
 
       if (command === 'MSG_FROM_APPSERVICE') {
-        WeixinJSBridge.subscribeHandler(msg.eventName, msg.data)
+        WgWebServiceJSBridge.subscribeHandler(msg.eventName, msg.data)
       } else if (
         command == 'GET_JSSDK_RES' ||
         command == 'INVOKE_SDK' ||
         /^private_/.test(msg.sdkName)
       ) {
-        WeixinJSBridge.subscribeHandler(msg.sdkName, msg.res, ext) // ext其实也没用 了
+        WgWebServiceJSBridge.subscribeHandler(msg.sdkName, msg.res, ext) // ext其实也没用 了
       } else if (command === 'STOP_PULL_DOWN_REFRESH') {
-        WeixinJSBridge.pull.reset()
+        WgWebServiceJSBridge.pull.reset()
       }
     })
   }

--- a/src/view/api/bridge.js
+++ b/src/view/api/bridge.js
@@ -46,7 +46,7 @@ function on(eventName, handler) {
   send(eventName, {}, true)
 }
 
-window.WgWebServiceJSBridge = {
+window.WeWebServiceJSBridge = {
   pull,
   invoke,
   on,
@@ -87,7 +87,7 @@ function publish() {
       timestamp: Date.now()
     }
   }
-  WgWebServiceJSBridge.publish.apply(WgWebServiceJSBridge, params)
+  WeWebServiceJSBridge.publish.apply(WeWebServiceJSBridge, params)
 }
 
 function subscribe() {
@@ -97,7 +97,7 @@ function subscribe() {
     var data = args.data
     typeof callback === 'function' && callback(data, ext)
   }
-  WgWebServiceJSBridge.subscribe.apply(WgWebServiceJSBridge, params)
+  WeWebServiceJSBridge.subscribe.apply(WeWebServiceJSBridge, params)
 }
 
 function invokeMethod(eventName, options = {}, hooks = {}) {

--- a/src/view/api/bridge.js
+++ b/src/view/api/bridge.js
@@ -46,7 +46,7 @@ function on(eventName, handler) {
   send(eventName, {}, true)
 }
 
-window.WeixinJSBridge = {
+window.WgWebServiceJSBridge = {
   pull,
   invoke,
   on,
@@ -87,7 +87,7 @@ function publish() {
       timestamp: Date.now()
     }
   }
-  WeixinJSBridge.publish.apply(WeixinJSBridge, params)
+  WgWebServiceJSBridge.publish.apply(WgWebServiceJSBridge, params)
 }
 
 function subscribe() {
@@ -97,7 +97,7 @@ function subscribe() {
     var data = args.data
     typeof callback === 'function' && callback(data, ext)
   }
-  WeixinJSBridge.subscribe.apply(WeixinJSBridge, params)
+  WgWebServiceJSBridge.subscribe.apply(WgWebServiceJSBridge, params)
 }
 
 function invokeMethod(eventName, options = {}, hooks = {}) {

--- a/src/view/components/wx-audio.js
+++ b/src/view/components/wx-audio.js
@@ -145,12 +145,12 @@ export default window.exparser.registerElement({
         typeof player[self.action.method] === 'function' &&
         player[self.action.method]()
     }
-    WgWebServiceJSBridge.subscribe('audio_' + this.id + '_actionChanged', function (
+    WeWebServiceJSBridge.subscribe('audio_' + this.id + '_actionChanged', function (
       t
     ) {
       self.action = t
     })
-    WgWebServiceJSBridge.publish('audioInsert', {
+    WeWebServiceJSBridge.publish('audioInsert', {
       audioId: this.id
     })
     wd.onAppEnterBackground(function (t) {

--- a/src/view/components/wx-audio.js
+++ b/src/view/components/wx-audio.js
@@ -145,12 +145,12 @@ export default window.exparser.registerElement({
         typeof player[self.action.method] === 'function' &&
         player[self.action.method]()
     }
-    WeixinJSBridge.subscribe('audio_' + this.id + '_actionChanged', function (
+    WgWebServiceJSBridge.subscribe('audio_' + this.id + '_actionChanged', function (
       t
     ) {
       self.action = t
     })
-    WeixinJSBridge.publish('audioInsert', {
+    WgWebServiceJSBridge.publish('audioInsert', {
       audioId: this.id
     })
     wd.onAppEnterBackground(function (t) {

--- a/src/view/components/wx-canvas.js
+++ b/src/view/components/wx-canvas.js
@@ -139,11 +139,11 @@ export default window.exparser.registerElement({
         window.__canvasNumber__ + __webviewId__
       window.__canvasNumber__ += 1e5
       this._canvasNumber = window.__canvasNumbers__[canvasId]
-      WeixinJSBridge.publish('canvasInsert', {
+      WgWebServiceJSBridge.publish('canvasInsert', {
         canvasId: self.canvasId,
         canvasNumber: self._canvasNumber
       })
-      WeixinJSBridge.subscribe(
+      WgWebServiceJSBridge.subscribe(
         'canvas' + self._canvasNumber + 'actionsChanged',
         function (params) {
           var actions = params.actions,
@@ -152,11 +152,11 @@ export default window.exparser.registerElement({
           self.actionsChanged(actions, reserve)
         }
       )
-      WeixinJSBridge.subscribe(
+      WgWebServiceJSBridge.subscribe(
         'invokeCanvasToDataUrl_' + self._canvasNumber,
         function () {
           var dataUrl = self.$.canvas.toDataURL()
-          WeixinJSBridge.publish('onCanvasToDataUrl_' + self._canvasNumber, {
+          WgWebServiceJSBridge.publish('onCanvasToDataUrl_' + self._canvasNumber, {
             dataUrl: dataUrl
           })
         }
@@ -172,7 +172,7 @@ export default window.exparser.registerElement({
   detached: function () {
     var canvasId = __webviewId__ + 'canvas' + this.canvasId
     delete window.__canvasNumbers__[canvasId]
-    WeixinJSBridge.publish('canvasRemove', {
+    WgWebServiceJSBridge.publish('canvasRemove', {
       canvasId: this.canvasId,
       canvasNumber: this._canvasNumber
     })

--- a/src/view/components/wx-canvas.js
+++ b/src/view/components/wx-canvas.js
@@ -139,11 +139,11 @@ export default window.exparser.registerElement({
         window.__canvasNumber__ + __webviewId__
       window.__canvasNumber__ += 1e5
       this._canvasNumber = window.__canvasNumbers__[canvasId]
-      WgWebServiceJSBridge.publish('canvasInsert', {
+      WeWebServiceJSBridge.publish('canvasInsert', {
         canvasId: self.canvasId,
         canvasNumber: self._canvasNumber
       })
-      WgWebServiceJSBridge.subscribe(
+      WeWebServiceJSBridge.subscribe(
         'canvas' + self._canvasNumber + 'actionsChanged',
         function (params) {
           var actions = params.actions,
@@ -152,11 +152,11 @@ export default window.exparser.registerElement({
           self.actionsChanged(actions, reserve)
         }
       )
-      WgWebServiceJSBridge.subscribe(
+      WeWebServiceJSBridge.subscribe(
         'invokeCanvasToDataUrl_' + self._canvasNumber,
         function () {
           var dataUrl = self.$.canvas.toDataURL()
-          WgWebServiceJSBridge.publish('onCanvasToDataUrl_' + self._canvasNumber, {
+          WeWebServiceJSBridge.publish('onCanvasToDataUrl_' + self._canvasNumber, {
             dataUrl: dataUrl
           })
         }
@@ -172,7 +172,7 @@ export default window.exparser.registerElement({
   detached: function () {
     var canvasId = __webviewId__ + 'canvas' + this.canvasId
     delete window.__canvasNumbers__[canvasId]
-    WgWebServiceJSBridge.publish('canvasRemove', {
+    WeWebServiceJSBridge.publish('canvasRemove', {
       canvasId: this.canvasId,
       canvasNumber: this._canvasNumber
     })

--- a/src/view/components/wx-input.js
+++ b/src/view/components/wx-input.js
@@ -247,7 +247,7 @@ export default !(function () {
           offsetTop: this.$$.offsetTop,
           offsetLeft: this.$$.offsetLeft
         }
-        WeixinJSBridge.publish('SPECIAL_PAGE_EVENT', {
+        WgWebServiceJSBridge.publish('SPECIAL_PAGE_EVENT', {
           eventName: this.bindinput,
           data: {
             ext: {

--- a/src/view/components/wx-input.js
+++ b/src/view/components/wx-input.js
@@ -247,7 +247,7 @@ export default !(function () {
           offsetTop: this.$$.offsetTop,
           offsetLeft: this.$$.offsetLeft
         }
-        WgWebServiceJSBridge.publish('SPECIAL_PAGE_EVENT', {
+        WeWebServiceJSBridge.publish('SPECIAL_PAGE_EVENT', {
           eventName: this.bindinput,
           data: {
             ext: {

--- a/src/view/components/wx-map.js
+++ b/src/view/components/wx-map.js
@@ -97,7 +97,7 @@ window.exparser.registerElement({
   _update: function (opt, t) {
     ;(opt.mapId = this._mapId),
     (opt.hide = this.hidden),
-    WeixinJSBridge.invoke('updateMap', opt, function (e) {})
+    WgWebServiceJSBridge.invoke('updateMap', opt, function (e) {})
   },
   _updatePosition: function () {},
   _transformPath: function (path, t) {
@@ -163,7 +163,7 @@ window.exparser.registerElement({
     this._mapId &&
       (((this.markers && this.markers.length > 0) ||
         (this.covers && this.covers.length > 0)) &&
-        WeixinJSBridge.invoke(
+        WgWebServiceJSBridge.invoke(
           'addMapMarkers',
           {
             mapId: this._mapId,
@@ -173,7 +173,7 @@ window.exparser.registerElement({
         ),
         this.includePoints &&
         this.includePoints.length > 0 &&
-        WeixinJSBridge.invoke(
+        WgWebServiceJSBridge.invoke(
           'includeMapPoints',
           {
             mapId: this._mapId,
@@ -183,7 +183,7 @@ window.exparser.registerElement({
         ),
         this.polyline &&
         this.polyline.length > 0 &&
-        WeixinJSBridge.invoke(
+        WgWebServiceJSBridge.invoke(
           'addMapLines',
           {
             mapId: this._mapId,
@@ -193,7 +193,7 @@ window.exparser.registerElement({
         ),
         this.circles &&
         this.circles.length > 0 &&
-        WeixinJSBridge.invoke(
+        WgWebServiceJSBridge.invoke(
           'addMapCircles',
           {
             mapId: this._mapId,
@@ -203,7 +203,7 @@ window.exparser.registerElement({
         ),
         this.controls &&
         this.controls.length > 0 &&
-        WeixinJSBridge.invoke(
+        WgWebServiceJSBridge.invoke(
           'addMapControls',
           {
             mapId: this._mapId,
@@ -252,11 +252,11 @@ window.exparser.registerElement({
       function () {
         self._mapId = __map_jssdk_id++
         self._ready()
-        WeixinJSBridge.subscribe('doMapAction' + self._mapId, function (res) {
+        WgWebServiceJSBridge.subscribe('doMapAction' + self._mapId, function (res) {
           if (self._map && self._mapId === res.data.mapId) {
             if (res.data.method === 'getMapCenterLocation') {
               var center = self._map.getCenter()
-              WeixinJSBridge.publish('doMapActionCallback', {
+              WgWebServiceJSBridge.publish('doMapActionCallback', {
                 mapId: self._mapId,
                 callbackId: res.data.callbackId,
                 method: res.data.method,
@@ -266,7 +266,7 @@ window.exparser.registerElement({
             } else {
               res.data.method === 'moveToMapLocation' &&
                 self.showLocation &&
-                WeixinJSBridge.invoke('private_geolocation', {}, function (res) {
+                WgWebServiceJSBridge.invoke('private_geolocation', {}, function (res) {
                   try {
                     res = JSON.parse(res)
                   } catch (e) {
@@ -285,7 +285,7 @@ window.exparser.registerElement({
             }
           }
         })
-        WeixinJSBridge.publish('mapInsert', {
+        WgWebServiceJSBridge.publish('mapInsert', {
           domId: self.id,
           mapId: self._mapId,
           showLocation: self.showLocation,
@@ -522,7 +522,7 @@ window.exparser.registerElement({
       ? (this._posOverlay &&
           (this._posOverlay.setMap(null), (this._posOverlay = null)),
         location &&
-          WeixinJSBridge.invoke('private_geolocation', {}, function (res) {
+          WgWebServiceJSBridge.invoke('private_geolocation', {}, function (res) {
             try {
               res = JSON.parse(res)
             } catch (e) {

--- a/src/view/components/wx-map.js
+++ b/src/view/components/wx-map.js
@@ -97,7 +97,7 @@ window.exparser.registerElement({
   _update: function (opt, t) {
     ;(opt.mapId = this._mapId),
     (opt.hide = this.hidden),
-    WgWebServiceJSBridge.invoke('updateMap', opt, function (e) {})
+    WeWebServiceJSBridge.invoke('updateMap', opt, function (e) {})
   },
   _updatePosition: function () {},
   _transformPath: function (path, t) {
@@ -163,7 +163,7 @@ window.exparser.registerElement({
     this._mapId &&
       (((this.markers && this.markers.length > 0) ||
         (this.covers && this.covers.length > 0)) &&
-        WgWebServiceJSBridge.invoke(
+        WeWebServiceJSBridge.invoke(
           'addMapMarkers',
           {
             mapId: this._mapId,
@@ -173,7 +173,7 @@ window.exparser.registerElement({
         ),
         this.includePoints &&
         this.includePoints.length > 0 &&
-        WgWebServiceJSBridge.invoke(
+        WeWebServiceJSBridge.invoke(
           'includeMapPoints',
           {
             mapId: this._mapId,
@@ -183,7 +183,7 @@ window.exparser.registerElement({
         ),
         this.polyline &&
         this.polyline.length > 0 &&
-        WgWebServiceJSBridge.invoke(
+        WeWebServiceJSBridge.invoke(
           'addMapLines',
           {
             mapId: this._mapId,
@@ -193,7 +193,7 @@ window.exparser.registerElement({
         ),
         this.circles &&
         this.circles.length > 0 &&
-        WgWebServiceJSBridge.invoke(
+        WeWebServiceJSBridge.invoke(
           'addMapCircles',
           {
             mapId: this._mapId,
@@ -203,7 +203,7 @@ window.exparser.registerElement({
         ),
         this.controls &&
         this.controls.length > 0 &&
-        WgWebServiceJSBridge.invoke(
+        WeWebServiceJSBridge.invoke(
           'addMapControls',
           {
             mapId: this._mapId,
@@ -252,11 +252,11 @@ window.exparser.registerElement({
       function () {
         self._mapId = __map_jssdk_id++
         self._ready()
-        WgWebServiceJSBridge.subscribe('doMapAction' + self._mapId, function (res) {
+        WeWebServiceJSBridge.subscribe('doMapAction' + self._mapId, function (res) {
           if (self._map && self._mapId === res.data.mapId) {
             if (res.data.method === 'getMapCenterLocation') {
               var center = self._map.getCenter()
-              WgWebServiceJSBridge.publish('doMapActionCallback', {
+              WeWebServiceJSBridge.publish('doMapActionCallback', {
                 mapId: self._mapId,
                 callbackId: res.data.callbackId,
                 method: res.data.method,
@@ -266,7 +266,7 @@ window.exparser.registerElement({
             } else {
               res.data.method === 'moveToMapLocation' &&
                 self.showLocation &&
-                WgWebServiceJSBridge.invoke('private_geolocation', {}, function (res) {
+                WeWebServiceJSBridge.invoke('private_geolocation', {}, function (res) {
                   try {
                     res = JSON.parse(res)
                   } catch (e) {
@@ -285,7 +285,7 @@ window.exparser.registerElement({
             }
           }
         })
-        WgWebServiceJSBridge.publish('mapInsert', {
+        WeWebServiceJSBridge.publish('mapInsert', {
           domId: self.id,
           mapId: self._mapId,
           showLocation: self.showLocation,
@@ -522,7 +522,7 @@ window.exparser.registerElement({
       ? (this._posOverlay &&
           (this._posOverlay.setMap(null), (this._posOverlay = null)),
         location &&
-          WgWebServiceJSBridge.invoke('private_geolocation', {}, function (res) {
+          WeWebServiceJSBridge.invoke('private_geolocation', {}, function (res) {
             try {
               res = JSON.parse(res)
             } catch (e) {

--- a/src/view/components/wx-picker-view-column.js
+++ b/src/view/components/wx-picker-view-column.js
@@ -466,7 +466,7 @@ export default !(function () {
       return this._current || 0
     },
     _setCurrent: function (indicator) {
-      this._current = indicator
+      this._current = indicator || 0
     },
     _setStyle: function (style) {
       this.$.indicator.setAttribute('style', style)
@@ -518,9 +518,12 @@ export default !(function () {
       this.__handleTouchMove = this._handleTouchMove.bind(this)
       this.__handleTouchEnd = this._handleTouchEnd.bind(this)
       this.$.main.addEventListener('touchstart', this.__handleTouchStart)
-      document.body.addEventListener('touchmove', this.__handleTouchMove)
-      document.body.addEventListener('touchend', this.__handleTouchEnd)
-      document.body.addEventListener('touchcancel', this.__handleTouchEnd)
+      this.$.main.addEventListener('touchmove', this.__handleTouchMove)
+      this.$.main.addEventListener('touchend', this.__handleTouchEnd)
+      this.$.main.addEventListener('touchcancel', this.__handleTouchEnd)
+      // document.body.addEventListener('touchmove', this.__handleTouchMove)
+      // document.body.addEventListener('touchend', this.__handleTouchEnd)
+      // document.body.addEventListener('touchcancel', this.__handleTouchEnd)
     },
     _update: function () {
       this._handlers.update(this._current)
@@ -575,7 +578,8 @@ export default !(function () {
     _handleTouchMove: function (event) {
       var touchInfo = this._touchInfo
       if (touchInfo.trackingID != -1) {
-        event.preventDefault()
+        event.preventDefault();
+        event.stopPropagation();
         var delta = this._findDelta(event)
         if (delta) {
           touchInfo.maxDy = Math.max(touchInfo.maxDy, Math.abs(delta.y))
@@ -597,7 +601,8 @@ export default !(function () {
     _handleTouchEnd: function (event) {
       var touchInfo = this._touchInfo
       if (touchInfo.trackingID != -1) {
-        event.preventDefault()
+        event.preventDefault();
+        event.stopPropagation();
         var delta = this._findDelta(event)
         if (delta) {
           var listener = touchInfo.listener

--- a/src/view/components/wx-picker.js
+++ b/src/view/components/wx-picker.js
@@ -92,7 +92,7 @@ export default window.exparser.registerElement({
         }
       }
 
-      WgWebServiceJSBridge.invoke(
+      WeWebServiceJSBridge.invoke(
         'showPickerView',
         {
           array: pickerData,
@@ -116,7 +116,7 @@ export default window.exparser.registerElement({
   showDatePickerView: function () {
     var _this = this
     if (!this.disabled) {
-      WgWebServiceJSBridge.invoke(
+      WeWebServiceJSBridge.invoke(
         'showDatePickerView',
         {
           range: {

--- a/src/view/components/wx-picker.js
+++ b/src/view/components/wx-picker.js
@@ -92,7 +92,7 @@ export default window.exparser.registerElement({
         }
       }
 
-      WeixinJSBridge.invoke(
+      WgWebServiceJSBridge.invoke(
         'showPickerView',
         {
           array: pickerData,
@@ -116,7 +116,7 @@ export default window.exparser.registerElement({
   showDatePickerView: function () {
     var _this = this
     if (!this.disabled) {
-      WeixinJSBridge.invoke(
+      WgWebServiceJSBridge.invoke(
         'showDatePickerView',
         {
           range: {

--- a/src/view/components/wx-scroll-view.js
+++ b/src/view/components/wx-scroll-view.js
@@ -69,7 +69,7 @@ export default window.exparser.registerElement({
     }
     this.__handleTouchStart = function (t) {
       ;(self.__touchStartY = t.touches[0].pageY),
-      WgWebServiceJSBridge.invoke(
+      WeWebServiceJSBridge.invoke(
         'disableScrollBounce',
         {
           disable: !0
@@ -85,7 +85,7 @@ export default window.exparser.registerElement({
           self._touchScrollLeft + main.offsetWidth === main.scrollWidth)
     }
     this.__handleTouchEnd = function () {
-      WgWebServiceJSBridge.invoke(
+      WeWebServiceJSBridge.invoke(
         'disableScrollBounce',
         {
           disable: !1

--- a/src/view/components/wx-scroll-view.js
+++ b/src/view/components/wx-scroll-view.js
@@ -69,7 +69,7 @@ export default window.exparser.registerElement({
     }
     this.__handleTouchStart = function (t) {
       ;(self.__touchStartY = t.touches[0].pageY),
-      WeixinJSBridge.invoke(
+      WgWebServiceJSBridge.invoke(
         'disableScrollBounce',
         {
           disable: !0
@@ -85,7 +85,7 @@ export default window.exparser.registerElement({
           self._touchScrollLeft + main.offsetWidth === main.scrollWidth)
     }
     this.__handleTouchEnd = function () {
-      WeixinJSBridge.invoke(
+      WgWebServiceJSBridge.invoke(
         'disableScrollBounce',
         {
           disable: !1

--- a/src/view/components/wx-slider.js
+++ b/src/view/components/wx-slider.js
@@ -77,7 +77,10 @@ export default window.exparser.registerElement({
   _onTrack: function (event) {
     if (!this.disabled) {
       return event.detail.state === 'move'
-        ? (this._onUserChangedValue(event), !1)
+        ? (this._onUserChangedValue(event), 
+        this.triggerEvent('changing', {
+          value: this.value
+        }), !1)
         : void (
           event.detail.state === 'end' &&
             this.triggerEvent('change', {
@@ -90,6 +93,9 @@ export default window.exparser.registerElement({
     this.disabled ||
       (this._onUserChangedValue(event),
         this.triggerEvent('change', {
+          value: this.value
+        }),
+        this.triggerEvent('changing', {
           value: this.value
         }))
   },

--- a/src/view/components/wx-textarea.js
+++ b/src/view/components/wx-textarea.js
@@ -234,7 +234,7 @@ export default !(function () {
           offsetTop: this.$$.offsetTop,
           offsetLeft: this.$$.offsetLeft
         }
-        WeixinJSBridge.publish('SPECIAL_PAGE_EVENT', {
+        WgWebServiceJSBridge.publish('SPECIAL_PAGE_EVENT', {
           eventName: this.bindinput,
           ext: {
             setKeyboardValue: !1

--- a/src/view/components/wx-textarea.js
+++ b/src/view/components/wx-textarea.js
@@ -234,7 +234,7 @@ export default !(function () {
           offsetTop: this.$$.offsetTop,
           offsetLeft: this.$$.offsetLeft
         }
-        WgWebServiceJSBridge.publish('SPECIAL_PAGE_EVENT', {
+        WeWebServiceJSBridge.publish('SPECIAL_PAGE_EVENT', {
           eventName: this.bindinput,
           ext: {
             setKeyboardValue: !1

--- a/src/view/components/wx-video.js
+++ b/src/view/components/wx-video.js
@@ -259,7 +259,7 @@ export const Video = window.exparser.registerElement({
   attached: function () {
     // var e = this
     var self = this
-    WeixinJSBridge.publish('videoPlayerInsert', {
+    WgWebServiceJSBridge.publish('videoPlayerInsert', {
       domId: this.id,
       videoPlayerId: 0
     })
@@ -317,7 +317,7 @@ export const Video = window.exparser.registerElement({
       })
     }
 
-    WeixinJSBridge.subscribe('video_' + this.id + '_actionChanged', function (
+    WgWebServiceJSBridge.subscribe('video_' + this.id + '_actionChanged', function (
       res
     ) {
       self.action = res

--- a/src/view/components/wx-video.js
+++ b/src/view/components/wx-video.js
@@ -259,7 +259,7 @@ export const Video = window.exparser.registerElement({
   attached: function () {
     // var e = this
     var self = this
-    WgWebServiceJSBridge.publish('videoPlayerInsert', {
+    WeWebServiceJSBridge.publish('videoPlayerInsert', {
       domId: this.id,
       videoPlayerId: 0
     })
@@ -317,7 +317,7 @@ export const Video = window.exparser.registerElement({
       })
     }
 
-    WgWebServiceJSBridge.subscribe('video_' + this.id + '_actionChanged', function (
+    WeWebServiceJSBridge.subscribe('video_' + this.id + '_actionChanged', function (
       res
     ) {
       self.action = res

--- a/src/view/components/wx-web-view.js
+++ b/src/view/components/wx-web-view.js
@@ -10,7 +10,7 @@ window.exparser.registerElement({
   srcChange: function (e, t) {
     if (this._isReady) {
       var n = this.uuid
-      WeixinJSBridge.invoke(
+      WgWebServiceJSBridge.invoke(
         'updateHTMLWebView',
         { htmlId: n, src: (e || '').trim() },
         function (e) {}
@@ -24,14 +24,14 @@ window.exparser.registerElement({
     this.uuid = this.getPositioningId()
     var t = this,
       n = this.uuid
-    wx.getSystemInfo({
+      wgweb_wx.getSystemInfo({
       success: function (e) {
         t.$$.style.width = e.windowWidth + 'px'
         t.$$.style.height = e.windowHeight + 'px'
         // var i = document.querySelector('body')
         // i.style.height = e.windowHeight + 'px'
         // i.style.overflowY = 'hidden'
-        WeixinJSBridge.invoke(
+        WgWebServiceJSBridge.invoke(
           'insertHTMLWebView',
           {
             htmlId: n,
@@ -52,7 +52,7 @@ window.exparser.registerElement({
   },
   detached: function () {
     var t = this.uuid
-    WeixinJSBridge.invoke('removeHTMLWebView', { htmlId: t }, t => {
+    WgWebServiceJSBridge.invoke('removeHTMLWebView', { htmlId: t }, t => {
       document.body.style.height = ''
       document.body.style.overflowY = ''
       this.inserted = !1

--- a/src/view/components/wx-web-view.js
+++ b/src/view/components/wx-web-view.js
@@ -10,7 +10,7 @@ window.exparser.registerElement({
   srcChange: function (e, t) {
     if (this._isReady) {
       var n = this.uuid
-      WgWebServiceJSBridge.invoke(
+      WeWebServiceJSBridge.invoke(
         'updateHTMLWebView',
         { htmlId: n, src: (e || '').trim() },
         function (e) {}
@@ -24,14 +24,14 @@ window.exparser.registerElement({
     this.uuid = this.getPositioningId()
     var t = this,
       n = this.uuid
-      wgweb_wx.getSystemInfo({
+      weweb_wx.getSystemInfo({
       success: function (e) {
         t.$$.style.width = e.windowWidth + 'px'
         t.$$.style.height = e.windowHeight + 'px'
         // var i = document.querySelector('body')
         // i.style.height = e.windowHeight + 'px'
         // i.style.overflowY = 'hidden'
-        WgWebServiceJSBridge.invoke(
+        WeWebServiceJSBridge.invoke(
           'insertHTMLWebView',
           {
             htmlId: n,
@@ -52,7 +52,7 @@ window.exparser.registerElement({
   },
   detached: function () {
     var t = this.uuid
-    WgWebServiceJSBridge.invoke('removeHTMLWebView', { htmlId: t }, t => {
+    WeWebServiceJSBridge.invoke('removeHTMLWebView', { htmlId: t }, t => {
       document.body.style.height = ''
       document.body.style.overflowY = ''
       this.inserted = !1

--- a/src/view/exparser-component.js
+++ b/src/view/exparser-component.js
@@ -35,9 +35,9 @@
   })
 })(window)
 
-// 订阅并转发 WgWebServiceJSBridge 提供的全局事件到 exparser
+// 订阅并转发 WeWebServiceJSBridge 提供的全局事件到 exparser
 ;(function (glob) {
-  WgWebServiceJSBridge.subscribe('onAppRouteDone', function () {
+  WeWebServiceJSBridge.subscribe('onAppRouteDone', function () {
     window.__onAppRouteDone = !0
     exparser.triggerEvent(
       document,
@@ -49,7 +49,7 @@
     )
     document.dispatchEvent(new CustomEvent('pageReRender', {}))
   })
-  WgWebServiceJSBridge.subscribe('setKeyboardValue', function (event) {
+  WeWebServiceJSBridge.subscribe('setKeyboardValue', function (event) {
     event &&
       event.data &&
       exparser.triggerEvent(
@@ -65,7 +65,7 @@
         }
       )
   })
-  WgWebServiceJSBridge.subscribe('hideKeyboard', function (e) {
+  WeWebServiceJSBridge.subscribe('hideKeyboard', function (e) {
     exparser.triggerEvent(
       document,
       'hideKeyboard',
@@ -75,7 +75,7 @@
       }
     )
   })
-  WgWebServiceJSBridge.on('onKeyboardComplete', function (event) {
+  WeWebServiceJSBridge.on('onKeyboardComplete', function (event) {
     exparser.triggerEvent(
       document,
       'onKeyboardComplete',
@@ -88,7 +88,7 @@
       }
     )
   })
-  WgWebServiceJSBridge.on('onKeyboardConfirm', function (event) {
+  WeWebServiceJSBridge.on('onKeyboardConfirm', function (event) {
     exparser.triggerEvent(
       document,
       'onKeyboardConfirm',
@@ -101,7 +101,7 @@
       }
     )
   })
-  WgWebServiceJSBridge.on('onTextAreaHeightChange', function (event) {
+  WeWebServiceJSBridge.on('onTextAreaHeightChange', function (event) {
     exparser.triggerEvent(
       document,
       'onTextAreaHeightChange',
@@ -115,7 +115,7 @@
       }
     )
   })
-  WgWebServiceJSBridge.on('onKeyboardShow', function (event) {
+  WeWebServiceJSBridge.on('onKeyboardShow', function (event) {
     exparser.triggerEvent(
       document,
       'onKeyboardShow',
@@ -456,14 +456,14 @@
               document.body.querySelectorAll(curData.element),
               ele
             ))
-          WgWebServiceJSBridge.publish('analyticsReport', {
+          WeWebServiceJSBridge.publish('analyticsReport', {
             data: data
           })
           break
         }
       }
     }
-  WgWebServiceJSBridge.subscribe('analyticsConfig', function (params) {
+  WeWebServiceJSBridge.subscribe('analyticsConfig', function (params) {
     if (Object.prototype.toString.call(params.data) === '[object Array]') {
       analyticsConfig.data = params.data
       analyticsConfig.selector = []

--- a/src/view/exparser-component.js
+++ b/src/view/exparser-component.js
@@ -35,9 +35,9 @@
   })
 })(window)
 
-// 订阅并转发 WeixinJSBridge 提供的全局事件到 exparser
+// 订阅并转发 WgWebServiceJSBridge 提供的全局事件到 exparser
 ;(function (glob) {
-  WeixinJSBridge.subscribe('onAppRouteDone', function () {
+  WgWebServiceJSBridge.subscribe('onAppRouteDone', function () {
     window.__onAppRouteDone = !0
     exparser.triggerEvent(
       document,
@@ -49,7 +49,7 @@
     )
     document.dispatchEvent(new CustomEvent('pageReRender', {}))
   })
-  WeixinJSBridge.subscribe('setKeyboardValue', function (event) {
+  WgWebServiceJSBridge.subscribe('setKeyboardValue', function (event) {
     event &&
       event.data &&
       exparser.triggerEvent(
@@ -65,7 +65,7 @@
         }
       )
   })
-  WeixinJSBridge.subscribe('hideKeyboard', function (e) {
+  WgWebServiceJSBridge.subscribe('hideKeyboard', function (e) {
     exparser.triggerEvent(
       document,
       'hideKeyboard',
@@ -75,7 +75,7 @@
       }
     )
   })
-  WeixinJSBridge.on('onKeyboardComplete', function (event) {
+  WgWebServiceJSBridge.on('onKeyboardComplete', function (event) {
     exparser.triggerEvent(
       document,
       'onKeyboardComplete',
@@ -88,7 +88,7 @@
       }
     )
   })
-  WeixinJSBridge.on('onKeyboardConfirm', function (event) {
+  WgWebServiceJSBridge.on('onKeyboardConfirm', function (event) {
     exparser.triggerEvent(
       document,
       'onKeyboardConfirm',
@@ -101,7 +101,7 @@
       }
     )
   })
-  WeixinJSBridge.on('onTextAreaHeightChange', function (event) {
+  WgWebServiceJSBridge.on('onTextAreaHeightChange', function (event) {
     exparser.triggerEvent(
       document,
       'onTextAreaHeightChange',
@@ -115,7 +115,7 @@
       }
     )
   })
-  WeixinJSBridge.on('onKeyboardShow', function (event) {
+  WgWebServiceJSBridge.on('onKeyboardShow', function (event) {
     exparser.triggerEvent(
       document,
       'onKeyboardShow',
@@ -456,14 +456,14 @@
               document.body.querySelectorAll(curData.element),
               ele
             ))
-          WeixinJSBridge.publish('analyticsReport', {
+          WgWebServiceJSBridge.publish('analyticsReport', {
             data: data
           })
           break
         }
       }
     }
-  WeixinJSBridge.subscribe('analyticsConfig', function (params) {
+  WgWebServiceJSBridge.subscribe('analyticsConfig', function (params) {
     if (Object.prototype.toString.call(params.data) === '[object Array]') {
       analyticsConfig.data = params.data
       analyticsConfig.selector = []


### PR DESCRIPTION
问题：wx-slider组件，滑动时无法触发changevalue
问题：小程序 app.json中如下配置项时。开发者会自己开发返回按钮，这样生成的页面自带返回按钮冲突。
问题：跳转带特殊参数传参时候，刷新h5页面会出现解码失败的问题：重复encode
增加新特性：可配置的页面icon和页面头，默认的请求方式为ajax，增加简单的缓存控制
问题：wx-picker-view组件，内部的wx-picker-view-column在滑动时会触发整个页面的滑动
更新readme中对xhr请求的描述
问题：解决生成的H5页面在微信中无法分享的问题