### PR TITLE
修改wx.showActionSheet的3个bug

### DIFF
--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -820,7 +820,7 @@ xpopup
 }
 
 .wx-action-sheet {
-  position: absolute;
+  position: fixed;
   left: 0;
   bottom: 0;
   transform: translate(0, 100%);
@@ -840,7 +840,7 @@ xpopup
 }
 
 .wx-action-sheet-mask {
-  position: absolute;
+  position: fixed;
   z-index: 1000;
   width: 100%;
   height: 100%;

--- a/src/service/bridge/command.js
+++ b/src/service/bridge/command.js
@@ -784,6 +784,9 @@ export function showActionSheet (data) {
   args.itemList = args.itemList.slice(0, 6)
   actionSheet(args).then(res => {
     onSuccess(data, res)
+  }).catch((res) => {
+    console.log('res', res);
+    onError(data, res)
   })
 }
 

--- a/src/service/lib/sdk/actionsheet.js
+++ b/src/service/lib/sdk/actionsheet.js
@@ -26,19 +26,17 @@ export default function ({ itemList, itemColor = '#000000' }) {
   if (el && el.parentNode) el.parentNode.removeChild(el)
 
   el = domify(fn({ itemList, itemColor }))
-  setTimeout(function () {
-    // 必须延迟一些，要不然会立即触发click
-    document.body.appendChild(el)
-  }, 100)
   let called = false
-  return new Promise(resolve => {
+  return new Promise((resolve,reject) => {
     el.addEventListener(
       'click',
       e => {
+        e.preventDefault();
+        e.stopPropagation();
         if (called) return
         if (classes(e.target).has('wx-action-sheet-mask')) {
           called = true
-          resolve({ cancel: true })
+          reject({ cancel:true, errMsg:"showActionSheet:fail cancel" })
         } else if (classes(e.target).has('wx-action-sheet-item')) {
           called = true
           resolve({
@@ -47,11 +45,16 @@ export default function ({ itemList, itemColor = '#000000' }) {
           })
         } else if (classes(e.target).has('wx-action-sheet-cancel')) {
           called = true
-          resolve({ cancel: true })
+          reject({ cancel:true, errMsg:"showActionSheet:fail cancel" })
         }
         if (called && el && el.parentNode) el.parentNode.removeChild(el)
       },
       false
     )
+    // 解决遮罩弹框事件穿透的问题
+    setTimeout(function () {
+      // 必须延迟一些，要不然会立即触发click
+      document.body.appendChild(el)
+    }, 100)
   })
 }


### PR DESCRIPTION
* 修改wx.showActionSheet存在的事件穿透问题，例如在页面底部有一个按钮点击触发showActionSheet，此时在ios中actionSheet会一闪而过
* 修改wx.showActionSheet中的success和fail回调，和微信小程序保持一致
* 修改wx.showActionSheet弹出来的遮罩层没有全屏的问题